### PR TITLE
Update 01-setup.rmd

### DIFF
--- a/01-setup.rmd
+++ b/01-setup.rmd
@@ -27,7 +27,7 @@ If you want to build multi-arch R package, make sure you install both 64bit and 
 Run This in R:
 
 ```r
-install.package("devtools")
+install.packages("devtools")
 devtools::install_github("rustr/rustinr")
 ```
 
@@ -36,6 +36,8 @@ And we are ready to Play!
 Run this in R console.
 
 ```r
+library(rustinr)
+
 rust(code ='
 // #[rustr_export]
 pub fn say_hi() -> String{
@@ -71,7 +73,7 @@ You can put Rust installation in path or set `CARGO_HOME` environment varible to
 Run This in R:
 
 ```r
-install.package("devtools")
+install.packages("devtools")
 devtools::install_github("rustr/rustinr")
 ```
 
@@ -86,6 +88,8 @@ And we are ready to Play!
 Run this in R console.
 
 ```r
+library(rustinr)
+
 rust(code ='
 // #[rustr_export]
 pub fn say_hi() -> String{
@@ -118,7 +122,7 @@ You can put Rust installation in path or set `CARGO_HOME` environment varible to
 Run This in R:
 
 ```r
-install.package("devtools")
+install.packages("devtools")
 devtools::install_github("rustr/rustinr")
 ```
 
@@ -127,6 +131,8 @@ And we are ready to Play!
 Run this in R console.
 
 ```{r}
+library(rustinr)
+
 rust('
 // #[rustr_export]
 pub fn say_hi() -> String{


### PR DESCRIPTION
Fix a typo with the package installation command.
Add the command `library(rustinr)` to be able to use `rust` command instead of `rustinr::rust(...)`